### PR TITLE
add css property for WP embed video

### DIFF
--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -10,3 +10,8 @@
   padding: 0;
   margin: 0;
 }
+
+div.wp-block-embed__wrapper iframe {
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
# Description
Added a global css class to force WordPress embedded videos to adjust its size to containing div parent

# Jira tickets

Please include a list with the tickets involved in this pull request :pray:
[
- [FE-### | Title]([link])](https://trialtech.atlassian.net/browse/FE-145)

# Screenshots

If you think a screenshot would be helpful to show this change, please attach it here :grin:

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue) :bug:
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) :bomb::boom:
- [ ] Configuration / Setup :wrench:
- [ ] Clean up / Technical debt :hammer:

## Apps affected by this change

- [x] Web
- [ ] Landing
- [ ] Management portal

## Project code modified by this change

- [X] Web
- [ ] Landing
- [ ] Management portal
- [ ] Packages

# Checklist:

- [X] I have performed a self-review of my own code :innocent:
- [X] My code is clean and it follows the guidelines of this project :nail_care:
- [X] My changes don't generate new warnings :ok_hand:
